### PR TITLE
Add 4 regions: aps2, apse4, euc2, eus2

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Available targets:
 |------|------|
 | [aws_iam_policy_document.by_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.by_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_regions.complete](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/regions) | data source |
 | [aws_regions.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/regions) | data source |
 | [aws_regions.not_opted_in](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/regions) | data source |
 | [aws_regions.opted_in](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/regions) | data source |
@@ -267,6 +268,7 @@ Available targets:
 
 | Name | Description |
 |------|-------------|
+| <a name="output_all_regions"></a> [all\_regions](#output\_all\_regions) | A list of all regions regardless of availability to the account |
 | <a name="output_disabled_regions"></a> [disabled\_regions](#output\_disabled\_regions) | A list of regions that are disabled in the account |
 | <a name="output_elb_logging_account"></a> [elb\_logging\_account](#output\_elb\_logging\_account) | Map of full region to ELB logging account |
 | <a name="output_elb_logging_s3_bucket_policy_json"></a> [elb\_logging\_s3\_bucket\_policy\_json](#output\_elb\_logging\_s3\_bucket\_policy\_json) | The S3 bucket policy (in JSON) to attach to the S3 bucket to allow Load Balancer logs to be added.<br>Requires `elb_logging_bucket_resource_arn` and `elb_logging_region` inputs. |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -24,6 +24,7 @@
 |------|------|
 | [aws_iam_policy_document.by_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.by_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_regions.complete](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/regions) | data source |
 | [aws_regions.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/regions) | data source |
 | [aws_regions.not_opted_in](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/regions) | data source |
 | [aws_regions.opted_in](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/regions) | data source |
@@ -57,6 +58,7 @@
 
 | Name | Description |
 |------|-------------|
+| <a name="output_all_regions"></a> [all\_regions](#output\_all\_regions) | A list of all regions regardless of availability to the account |
 | <a name="output_disabled_regions"></a> [disabled\_regions](#output\_disabled\_regions) | A list of regions that are disabled in the account |
 | <a name="output_elb_logging_account"></a> [elb\_logging\_account](#output\_elb\_logging\_account) | Map of full region to ELB logging account |
 | <a name="output_elb_logging_s3_bucket_policy_json"></a> [elb\_logging\_s3\_bucket\_policy\_json](#output\_elb\_logging\_s3\_bucket\_policy\_json) | The S3 bucket policy (in JSON) to attach to the S3 bucket to allow Load Balancer logs to be added.<br>Requires `elb_logging_bucket_resource_arn` and `elb_logging_region` inputs. |

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -58,10 +58,35 @@ output "disabled_regions" {
   value       = module.example.disabled_regions
 }
 
+output "all_regions" {
+  description = "A list of regions that are available to the account"
+  value       = module.example.all_regions
+}
+
 output "elb_logging_s3_bucket_policy_json" {
   description = <<-EOT
     The S3 bucket policy (in JSON) to attach to the S3 bucket to allow Load Balancer logs to be added.
     Requires `elb_logging_bucket_resource_arn` and `elb_logging_region` inputs.
     EOT
   value       = module.example.elb_logging_s3_bucket_policy_json
+}
+
+output "region_az_alt_code_maps" {
+  description = <<-EOT
+    Collection of maps converting between official AWS Region, Availability Zone, and Local Zone codes and shorter unofficial codes using only lower case letters and digits. Inspired for use in naming and tagging so that region or AZ code will be 1 semantic unit.
+
+    - `to_fixed` = Map of regions to 3-character codes and Availability Zones to 4-character codes
+    - `to_short` = Map of regions and Availability Zones to compact (usually 4-6 characters) codes
+    - `from_fixed` = Map of `fixed` codes back to full region or Availability Zone codes
+    - `from_short` = Map of `short` codes back to full region or Availability Zone codes
+    - `identity` = Identity map of full region and Availability Zone codes back to themselves
+    EOT
+  value       = module.example.region_az_alt_code_maps
+}
+
+output "region_display_name_map" {
+  description = <<-EOT
+    Map of full region names to user-friendly display names (e.g. "eu-west-3" = "Europe (Paris)").
+    EOT
+  value       = module.example.region_display_name_map
 }

--- a/main.tf
+++ b/main.tf
@@ -31,13 +31,17 @@ locals {
     "ap-northeast-2" = "Asia Pacific (Seoul)"
     "ap-northeast-3" = "Asia Pacific (Osaka)"
     "ap-south-1"     = "Asia Pacific (Mumbai)"
+    "ap-south-2"     = "Asia Pacific (Hyderabad)"
     "ap-southeast-1" = "Asia Pacific (Singapore)"
     "ap-southeast-2" = "Asia Pacific (Sydney)"
     "ap-southeast-3" = "Asia Pacific (Jakarta)"
+    "ap-southeast-4" = "Asia Pacific (Melbourne)"
     "ca-central-1"   = "Canada (Central)"
     "eu-central-1"   = "Europe (Frankfurt)"
+    "eu-central-2"   = "Europe (Zurich)"
     "eu-north-1"     = "Europe (Stockholm)"
     "eu-south-1"     = "Europe (Milan)"
+    "eu-south-2"     = "Europe (Milan)"
     "eu-west-1"      = "Europe (Ireland)"
     "eu-west-2"      = "Europe (London)"
     "eu-west-3"      = "Europe (Paris)"
@@ -89,7 +93,14 @@ locals {
     "ap-northeast-3a" = "an3a"
     "ap-northeast-3b" = "an3b"
     "ap-northeast-3c" = "an3c"
+    "ap-northeast-3d" = "an3d"
+    "ap-northeast-3e" = "an3e"
+    "ap-northeast-3f" = "an3f"
+    "ap-northeast-3g" = "an3g"
+    "ap-northeast-3h" = "an3h"
 
+    # Abbreviation for ap-south-1 would be "as1" but that is already used for ap-southeast-1
+    # So we use "as0" for ap-south-1
     "ap-south-1"  = "as0"
     "ap-south-1a" = "as0a"
     "ap-south-1b" = "as0b"
@@ -99,6 +110,20 @@ locals {
     "ap-south-1f" = "as0f"
     "ap-south-1g" = "as0g"
     "ap-south-1h" = "as0h"
+
+    # Abbreviation for ap-south-2 would be "as2" but that is already used for ap-southeast-2
+    # Using a different number as we did for ap-south-1 in not as extensible as using a different letter,
+    # which allows us to leaves the region number consistent.
+    # So we use "ar2" (r is letter before s) for ap-south-2
+    "ap-south-2"  = "ar2"
+    "ap-south-2a" = "ar2a"
+    "ap-south-2b" = "ar2b"
+    "ap-south-2c" = "ar2c"
+    "ap-south-2d" = "ar2d"
+    "ap-south-2e" = "ar2e"
+    "ap-south-2f" = "ar2f"
+    "ap-south-2g" = "ar2g"
+    "ap-south-2h" = "ar2h"
 
     "ap-southeast-1"  = "as1"
     "ap-southeast-1a" = "as1a"
@@ -130,6 +155,16 @@ locals {
     "ap-southeast-3g" = "as3g"
     "ap-southeast-3h" = "as3h"
 
+    "ap-southeast-4"  = "as4"
+    "ap-southeast-4a" = "as4a"
+    "ap-southeast-4b" = "as4b"
+    "ap-southeast-4c" = "as4c"
+    "ap-southeast-4d" = "as4d"
+    "ap-southeast-4e" = "as4e"
+    "ap-southeast-4f" = "as4f"
+    "ap-southeast-4g" = "as4g"
+    "ap-southeast-4h" = "as4h"
+
     "ca-central-1"  = "cc1"
     "ca-central-1a" = "cc1a"
     "ca-central-1b" = "cc1b"
@@ -150,6 +185,16 @@ locals {
     "eu-central-1g" = "ec1g"
     "eu-central-1h" = "ec1h"
 
+    "eu-central-2"  = "ec2"
+    "eu-central-2a" = "ec2a"
+    "eu-central-2b" = "ec2b"
+    "eu-central-2c" = "ec2c"
+    "eu-central-2d" = "ec2d"
+    "eu-central-2e" = "ec2e"
+    "eu-central-2f" = "ec2f"
+    "eu-central-2g" = "ec2g"
+    "eu-central-2h" = "ec2h"
+
     "eu-north-1"  = "en1"
     "eu-north-1a" = "en1a"
     "eu-north-1b" = "en1b"
@@ -169,6 +214,16 @@ locals {
     "eu-south-1f" = "es1f"
     "eu-south-1g" = "es1g"
     "eu-south-1h" = "es1h"
+
+    "eu-south-2"  = "es2"
+    "eu-south-2a" = "es2a"
+    "eu-south-2b" = "es2b"
+    "eu-south-2c" = "es2c"
+    "eu-south-2d" = "es2d"
+    "eu-south-2e" = "es2e"
+    "eu-south-2f" = "es2f"
+    "eu-south-2g" = "es2g"
+    "eu-south-2h" = "es2h"
 
     "eu-west-1"  = "ew1"
     "eu-west-1a" = "ew1a"
@@ -399,6 +454,11 @@ locals {
     "ap-northeast-3a" = "apne3a"
     "ap-northeast-3b" = "apne3b"
     "ap-northeast-3c" = "apne3c"
+    "ap-northeast-3d" = "apne3d"
+    "ap-northeast-3e" = "apne3e"
+    "ap-northeast-3f" = "apne3f"
+    "ap-northeast-3g" = "apne3g"
+    "ap-northeast-3h" = "apne3h"
 
     "ap-south-1"  = "aps1"
     "ap-south-1a" = "aps1a"
@@ -409,6 +469,16 @@ locals {
     "ap-south-1f" = "aps1f"
     "ap-south-1g" = "aps1g"
     "ap-south-1h" = "aps1h"
+
+    "ap-south-2"  = "aps2"
+    "ap-south-2a" = "aps2a"
+    "ap-south-2b" = "aps2b"
+    "ap-south-2c" = "aps2c"
+    "ap-south-2d" = "aps2d"
+    "ap-south-2e" = "aps2e"
+    "ap-south-2f" = "aps2f"
+    "ap-south-2g" = "aps2g"
+    "ap-south-2h" = "aps2h"
 
     "ap-southeast-1"  = "apse1"
     "ap-southeast-1a" = "apse1a"
@@ -440,6 +510,16 @@ locals {
     "ap-southeast-3g" = "apse3g"
     "ap-southeast-3h" = "apse3h"
 
+    "ap-southeast-4"  = "apse4"
+    "ap-southeast-4a" = "apse4a"
+    "ap-southeast-4b" = "apse4b"
+    "ap-southeast-4c" = "apse4c"
+    "ap-southeast-4d" = "apse4d"
+    "ap-southeast-4e" = "apse4e"
+    "ap-southeast-4f" = "apse4f"
+    "ap-southeast-4g" = "apse4g"
+    "ap-southeast-4h" = "apse4h"
+
     "ca-central-1"  = "cac1"
     "ca-central-1a" = "cac1a"
     "ca-central-1b" = "cac1b"
@@ -460,6 +540,16 @@ locals {
     "eu-central-1g" = "euc1g"
     "eu-central-1h" = "euc1h"
 
+    "eu-central-2"  = "euc2"
+    "eu-central-2a" = "euc2a"
+    "eu-central-2b" = "euc2b"
+    "eu-central-2c" = "euc2c"
+    "eu-central-2d" = "euc2d"
+    "eu-central-2e" = "euc2e"
+    "eu-central-2f" = "euc2f"
+    "eu-central-2g" = "euc2g"
+    "eu-central-2h" = "euc2h"
+
     "eu-north-1"  = "eun1"
     "eu-north-1a" = "eun1a"
     "eu-north-1b" = "eun1b"
@@ -479,6 +569,16 @@ locals {
     "eu-south-1f" = "eus1f"
     "eu-south-1g" = "eus1g"
     "eu-south-1h" = "eus1h"
+
+    "eu-south-2"  = "eus2"
+    "eu-south-2a" = "eus2a"
+    "eu-south-2b" = "eus2b"
+    "eu-south-2c" = "eus2c"
+    "eu-south-2d" = "eus2d"
+    "eu-south-2e" = "eus2e"
+    "eu-south-2f" = "eus2f"
+    "eu-south-2g" = "eus2g"
+    "eu-south-2h" = "eus2h"
 
     "eu-west-1"  = "euw1"
     "eu-west-1a" = "euw1a"
@@ -697,4 +797,8 @@ data "aws_regions" "not_opted_in" {
     name   = "opt-in-status"
     values = ["not-opted-in"]
   }
+}
+
+data "aws_regions" "complete" {
+  all_regions = true
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -50,3 +50,8 @@ output "disabled_regions" {
   value       = data.aws_regions.not_opted_in.names
 }
 
+output "all_regions" {
+  description = "A list of all regions regardless of availability to the account"
+  value       = data.aws_regions.complete.names
+}
+

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -53,6 +53,17 @@ func TestExamplesComplete(t *testing.T) {
 	fixedRoundTrip := terraform.Output(t, terraformOptions, "fixed_round_trip")
 	shortRoundTrip := terraform.Output(t, terraformOptions, "short_round_trip")
 	enabledRegions := terraform.OutputList(t, terraformOptions, "enabled_regions")
+	allRegions := terraform.OutputList(t, terraformOptions, "all_regions")
+	displayNames := terraform.OutputMap(t, terraformOptions, "region_display_name_map")
+	abbreviationMaps := terraform.OutputMapOfObjects(t, terraformOptions, "region_az_alt_code_maps")
+
+	for _, reg := range allRegions {
+		for _, k := range []string{"to_fixed", "to_short", "identity"} {
+			assert.Contains(t, abbreviationMaps[k], reg, "Abbreviation map "+k+" is missing entry for region "+reg)
+		}
+		assert.Contains(t, displayNames, reg, "Display Names map is missing entry for region "+reg)
+	}
+
 	//disabledRegions := terraform.OutputList(t, terraformOptions, "disabled_regions")
 	idSize := terraform.Output(t, terraformOptions, "identity_size")
 
@@ -70,7 +81,6 @@ func TestExamplesComplete(t *testing.T) {
 	assert.Equal(t, idSize, terraform.Output(t, terraformOptions, "to_fixed_size"), "Transformation maps are different sizes")
 	assert.Equal(t, idSize, terraform.Output(t, terraformOptions, "from_short_size"), "Transformation maps are different sizes")
 	assert.Equal(t, idSize, terraform.Output(t, terraformOptions, "from_fixed_size"), "Transformation maps are different sizes")
-
 }
 
 func TestExamplesCompleteDisabled(t *testing.T) {


### PR DESCRIPTION
## what

Add 4 newest regions:

1. "ap-south-2"  = "Asia Pacific (Hyderabad)" (Note: fixed code is `ar2` because `as2` is taken by `ap-southeast-2`)
2. "ap-southeast-4"  = "Asia Pacific (Melbourne)"
3. "eu-central-2"  = "Europe (Zurich)"
4. "eu-south-2"  = "Europe (Spain)"

- Add `all_regions` output
- When testing, check to make sure all regions have abbreviations


## why

- Provide full coverage.

## references

- Closes #24 
- Supersedes and closes #25 

